### PR TITLE
Fix TTL configuration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # 6.0.10: FROM debian:bullseye-slim
-FROM varnish:6.0.11
+FROM varnish:6.0.13
 
 RUN mkdir /build /app
 WORKDIR /build

--- a/src/varnish/default.vcl
+++ b/src/varnish/default.vcl
@@ -40,9 +40,17 @@ sub vcl_backend_response {
   if (std.getenv("NO_CACHING") == "true") {
     set beresp.uncacheable = true;
     set beresp.ttl = 15m;
-  } else {
+  } elseif (beresp.status >= 200 && beresp.status < 300) {
     set beresp.ttl = std.duration(std.getenv("BERESP_TTL"), 1m);
     set beresp.grace = std.duration(std.getenv("BERESP_GRACE"), 1m);
     set beresp.keep = std.duration(std.getenv("BERESP_KEEP"), 1m);
+  } else if (beresp.status == 408 || beresp.status == 504) {
+    // for timeout
+    set beresp.ttl = 5m;
+    set beresp.grace = 10m;
+    set beresp.keep = 5m;
+  } else {
+    set beresp.uncacheable = true;
+    set beresp.ttl = 15m;
   }
 }


### PR DESCRIPTION
It was configured to cache non-success responses for full TTL meant for successes. https://github.com/project-lux/lux-webcache/issues/1